### PR TITLE
Wip ldap

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -10,6 +10,8 @@ class racktables::apache inherits racktables {
   }
 
   class {'::apache::mod::php': }
+  class {'::apache::mod::auth_basic': }
+  class {'::apache::mod::authnz_ldap': }
 
   apache::vhost { "${vhost}-http":
     servername      => "${vhost}",
@@ -31,6 +33,7 @@ class racktables::apache inherits racktables {
     error_log_file  => "${vhost}_error_ssl_log",
     ssl             => true,
     require         => vcsrepo[$datadir],
+    override        => 'AuthConfig',
   }
 
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -24,6 +24,7 @@ class racktables::install inherits racktables {
       'php5-gd',
       'php5-mysql',
       'php5-snmp',
+      'php5-ldap',
       ]:
         ensure => present,
       }


### PR DESCRIPTION
This will allow for LDAP authentication by creating a file `/usr/local/share/RackTables/wwwroot/.htaccess` with content like

```
AuthBasicProvider ldap
AuthType Basic
AuthName "Restricted"
require ldap-attribute objectClass=posixAccount
AuthzLDAPAuthoritative on
AuthLDAPURL ldap://ldap.example.org/ou=users,dc=example,dc=org?uid
Require valid-user
´´´